### PR TITLE
Update helpText for CommandAirbridge.java

### DIFF
--- a/Minebot/src/net/famzangl/minecraft/minebot/ai/commands/CommandAirbridge.java
+++ b/Minebot/src/net/famzangl/minecraft/minebot/ai/commands/CommandAirbridge.java
@@ -10,7 +10,7 @@ import net.famzangl.minecraft.minebot.ai.strategy.AIStrategy;
 import net.famzangl.minecraft.minebot.ai.strategy.AirbridgeStrategy;
 import net.minecraft.util.EnumFacing;
 
-@AICommand(helpText = "Build a tunnel with the given profile", name = "minebot")
+@AICommand(helpText = "Builds an airbridge using the half-slabs in your inventory.", name = "minebot")
 public class CommandAirbridge {
 	public enum AirbridgeWidth {
 		SMALL(0,0),
@@ -30,9 +30,9 @@ public class CommandAirbridge {
 	public static AIStrategy run(
 			AIHelper helper,
 			@AICommandParameter(type = ParameterType.FIXED, fixedName = "airbridge", description = "") String nameArg,
-			@AICommandParameter(type = ParameterType.ENUM, description = "direction", optional = true) EnumFacing inDirection,
-			@AICommandParameter(type = ParameterType.NUMBER, description = "max length", optional = true) Integer length,
-			@AICommandParameter(type = ParameterType.ENUM, description = "width", optional = true) AirbridgeWidth width) {
+			@AICommandParameter(type = ParameterType.ENUM, description = "direction: North, South, East, West", optional = true) EnumFacing inDirection,
+			@AICommandParameter(type = ParameterType.NUMBER, description = "max distance to travel", optional = true) Integer length,
+			@AICommandParameter(type = ParameterType.ENUM, description = "small, wide, wider, maximum", optional = true) AirbridgeWidth width) {
 		if (width == null) {
 			width = AirbridgeWidth.SMALL;
 		}


### PR DESCRIPTION
Updated help text to clarify parameters.

Changed Max length to max distance to travel because if the user is standing on an airbridge and runs /minebot airbridge 7 the bot will walk 7 blocks and stop. This may or may not be intended. If it is a bug we should change it to walk to the end of the current bridge before building 7 blocks.
